### PR TITLE
fix: include game-shared in build:packages filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "pnpm -r test",
     "check:sync": "node tools/check-testing-sync.mjs",
     "test:coverage": "vitest run --coverage",
-    "build:packages": "pnpm --filter '@broblox/*' --filter '!@broblox/game-*' --filter '@broblox/game-shared' run build:roblox",
+    "build:packages": "pnpm --filter '@broblox/*' --filter '!@broblox/game-obby' --filter '!@broblox/game-test-park' run build:roblox",
     "build:test-park": "pnpm run build:packages && pnpm --filter @broblox/game-test-park run build",
     "build:obby": "pnpm run build:packages && pnpm --filter @broblox/game-obby run build",
     "game:test-park:build": "pnpm run build:test-park",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "pnpm -r test",
     "check:sync": "node tools/check-testing-sync.mjs",
     "test:coverage": "vitest run --coverage",
-    "build:packages": "pnpm --filter '@broblox/*' --filter '!@broblox/game-*' run build:roblox",
+    "build:packages": "pnpm --filter '@broblox/*' --filter '!@broblox/game-*' --filter '@broblox/game-shared' run build:roblox",
     "build:test-park": "pnpm run build:packages && pnpm --filter @broblox/game-test-park run build",
     "build:obby": "pnpm run build:packages && pnpm --filter @broblox/game-obby run build",
     "game:test-park:build": "pnpm run build:test-park",


### PR DESCRIPTION
## Problem

`build:packages` uses `--filter '!@broblox/game-*'` to exclude game projects, but this also excludes `@broblox/game-shared` (a library package, not a game). Without compilation, the games can't resolve `@broblox/game-shared` via `node_modules` since `package.json` points to `out/` which doesn't exist.

This caused:
```
src/shared/remotes.ts:54:8 - error TS2307: Cannot find module '@broblox/game-shared'
```

## Fix

Added `--filter '@broblox/game-shared'` to re-include it in the package build step:
```
"build:packages": "pnpm --filter '@broblox/*' --filter '!@broblox/game-*' --filter '@broblox/game-shared' run build:roblox"
```

Verified locally: game-shared compiles and obby typecheck passes.