### PR TITLE
docs: sync docs with current codebase (37 packages, game-shared, input factory)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Notes:
 - **Rollup security patch** — added pnpm override `rollup@>=4.0.0 <4.59.0: ">=4.59.0"` to fix GHSA-mw96-cpmx-2vgc. All `@rollup/*` platform packages upgraded 4.55.2 → 4.59.0.
 - **tsconfig.roblox.json** — added `@broblox/events` path alias.
 - **vitest.config.ts** — added `@broblox/marketplace` alias.
-- **Docs sync** — updated `NEXT-SESSION.md`, `README.md`, `docs/roadmap/overview.md`, `docs/roadmap/future-phases.md`, `docs/architecture/folders-and-packages.md`, and `docs/architecture/platform.md` to reflect 37 packages, Phase 5d complete status, and marketplace addition.
+- **Docs sync** — updated `README.md`, `docs/roadmap/overview.md`, `docs/getting-started/overview.md`, `docs/architecture/folders-and-packages.md`, and `docs/architecture/platform.md` to reflect 37 packages, Phase 5d complete status, game-shared addition, and marketplace addition.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Notes:
 - **Rollup security patch** — added pnpm override `rollup@>=4.0.0 <4.59.0: ">=4.59.0"` to fix GHSA-mw96-cpmx-2vgc. All `@rollup/*` platform packages upgraded 4.55.2 → 4.59.0.
 - **tsconfig.roblox.json** — added `@broblox/events` path alias.
 - **vitest.config.ts** — added `@broblox/marketplace` alias.
-- **Docs sync** — updated `NEXT-SESSION.md`, `README.md`, `docs/roadmap/overview.md`, `docs/roadmap/future-phases.md`, `docs/architecture/folders-and-packages.md`, and `docs/architecture/platform.md` to reflect 33 packages, Phase 4 complete status, and marketplace addition.
+- **Docs sync** — updated `NEXT-SESSION.md`, `README.md`, `docs/roadmap/overview.md`, `docs/roadmap/future-phases.md`, `docs/architecture/folders-and-packages.md`, and `docs/architecture/platform.md` to reflect 37 packages, Phase 5d complete status, and marketplace addition.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ BroBlox game studio — Roblox-TS multi-game platform + control-plane dashboard.
 
 ```
 broblox/
-├── packages/                 # 33 shared platform packages (TypeScript → Luau)
+├── packages/                 # 37 shared platform packages (TypeScript → Luau)
 │   ├── shared-types/         # Core type definitions, Result<T>, ErrorCode
 │   ├── constants/            # Numeric constants, timeouts, limits, validation helpers
 │   ├── core/                 # Application lifecycle, Logger, Cleanup, collection helpers
@@ -49,6 +49,10 @@ broblox/
 │   ├── input/                # Unified input (keyboard, gamepad, touch)
 │   ├── ui/                   # UI components, theming, layout utilities
 │   ├── marketplace/          # MonetizationService wrapper: developer products, game passes, receipt validation
+│   ├── game-shared/          # Shared remote payload types for cross-game remotes
+│   ├── equipment/            # Gear & equipment slot system with stat bonuses
+│   ├── hazards/              # Environmental hazard system (lava, spikes, poison)
+│   ├── obstacles/            # Dynamic obstacle system (platforms, beams, conveyors)
 │   └── testing/              # Test utilities and Roblox API mocks for vitest
 ├── games/                    # Roblox-TS game projects
 │   ├── test-park/              # Test Park sandbox (staff-only)

--- a/docs/architecture/folders-and-packages.md
+++ b/docs/architecture/folders-and-packages.md
@@ -96,6 +96,12 @@ This project is intended to be a **monorepo** with many games sharing a common p
   - Higher-level components: `Dialog`, `Toast`, `ListView`, `ProgressBar`, `Spinner`.
   - Device-safe sizing with `px()` and `scale()` helpers.
 
+- `game-shared`
+  - Shared remote payload types used across all games' remote definitions.
+  - `RemoteRewardEntry`, `LevelUpPayload`, `QuestCompletedPayload`, `AchievementCompletedPayload`, `DailyRewardClaimedPayload`, `PrestigeUnlockedPayload`, `EventActivePayload`.
+  - Games import from `@broblox/game-shared` instead of duplicating interfaces.
+  - Depends on `@broblox/rewards` for `RewardType`.
+
 - `testing`
   - Shared test utilities for vitest.
   - Roblox API mocks for Node.js.

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -1,13 +1,13 @@
 # Getting started: Overview
 
-This project is a **monorepo platform** with 33 shared packages, 2 games, a web dashboard, and full CI/CD.
+This project is a **monorepo platform** with 37 shared packages, 2 games, a web dashboard, and full CI/CD.
 
 ## Intended stack
 
 - Roblox game code: **roblox-ts** (TypeScript → Luau)
 - Project sync/build: **Rojo** (filesystem → DataModel)
 - Dependencies: **pnpm** workspaces
-- Formatting/linting/testing: ESLint + Prettier + **vitest** (3,100+ tests across 150+ test files)
+- Formatting/linting/testing: ESLint + Prettier + **vitest** (3,773 tests across 172 test suites)
 - CI/CD: GitHub Actions + Roblox **Open Cloud**
 - Docs hosting: static **MkDocs** site
 - Web dashboard: **Next.js** + Prisma (audit logs, config history, moderation workflow)
@@ -36,5 +36,7 @@ This project is a **monorepo platform** with 33 shared packages, 2 games, a web 
 | 5a    | inventory, progression, quests, rewards                                                                    | ✅     |
 | 5b    | pets, gacha, cosmetics, battle-pass                                                                        | ✅     |
 | 5c    | localization, audio, tutorial, world-systems                                                               | ✅     |
+| 5d    | equipment, hazards, obstacles                                                                              | ✅     |
+| —     | game-shared (cross-game payload types)                                                                     | ✅     |
 
 Games: **test-park** (sandbox / platform test park) and **obby** (checkpoint/coin game).

--- a/docs/modules/game-shared.md
+++ b/docs/modules/game-shared.md
@@ -36,7 +36,7 @@ import type {
 
 ## Testing
 
-- Type-level tests validate all exported interfaces.
+- Package-level smoke tests ensure the module is importable; exported types are validated via TypeScript compilation in consuming games.
 
 ## See Also
 

--- a/docs/modules/game-shared.md
+++ b/docs/modules/game-shared.md
@@ -1,0 +1,44 @@
+# Modules: Game Shared
+
+Shared remote payload types used across all games (`@broblox/game-shared`). **Status: Implemented** (7 types).
+
+## Purpose
+
+- Define common interfaces for remote event payloads so all games use the same shapes.
+- Eliminate duplicated type definitions across game `remotes.ts` files.
+- Provide a single import source for payload types used by notifications, rewards, and events.
+
+## Data model
+
+- `RemoteRewardEntry` — `type` (`RewardType`), `amount`, `itemId?`, `label?`.
+- `LevelUpPayload` — `newLevel`.
+- `PrestigeUnlockedPayload` — `newPrestige`.
+- `QuestCompletedPayload` — `questId`, `rewards: RemoteRewardEntry[]`.
+- `AchievementCompletedPayload` — `achievementId`, `rewards: RemoteRewardEntry[]`.
+- `DailyRewardClaimedPayload` — `day`, `streak`, `rewards: RemoteRewardEntry[]`.
+- `EventActivePayload` — `id`, `label`, `modifiers?`.
+
+## Usage
+
+Games import payload types from `@broblox/game-shared` in their `remotes.ts`:
+
+```typescript
+import type {
+  RemoteRewardEntry,
+  LevelUpPayload,
+  QuestCompletedPayload,
+} from "@broblox/game-shared";
+```
+
+## Dependencies
+
+- `@broblox/rewards` — `RewardType` enum used by `RemoteRewardEntry`.
+
+## Testing
+
+- Type-level tests validate all exported interfaces.
+
+## See Also
+
+- [Net module](net.md) — remote registry where these payloads are used
+- [Rewards module](rewards.md) — `RewardType` definition

--- a/docs/modules/input.md
+++ b/docs/modules/input.md
@@ -11,6 +11,24 @@ Unified input abstraction for Roblox games supporting keyboard/mouse, gamepad, a
 
 ## Public API
 
+### createInputController()
+
+Factory function that returns a `Controller`-compatible handle for the input system, following the same factory pattern as server-side packages (`createCombatService`, `createQuestService`, etc.).
+
+```typescript
+import { createInputController } from "@broblox/input";
+
+const input = createInputController();
+// input.Controller — register with lifecycle system
+// input.getMovementState() — current movement state
+// input.getMoveVector() — normalized movement vector
+// input.isMoving() — whether player is moving
+// input.isActionActive(name) — check if action is pressed
+// input.onAction(name, callback) — subscribe to action events
+// input.getCurrentDevice() — "keyboard" | "gamepad" | "touch"
+// input.detectDeviceClass() — "kbm" | "gamepad" | "touch"
+```
+
 ### Device Detection
 
 Detect the player's active input device class at runtime.

--- a/docs/roadmap/overview.md
+++ b/docs/roadmap/overview.md
@@ -9,7 +9,7 @@ This is the single source of truth for BroBlox project planning. Raw brainstormi
 
 ## Where we are today
 
-The platform is **feature-complete through Phase 5d** — 35 packages, 2 games, a dashboard, and a website. All infrastructure is built, tested (3,370+ tests), and deployed.
+The platform is **feature-complete through Phase 5d** — 37 packages, 2 games, a dashboard, and a website. All infrastructure is built, tested (3,773 tests across 172 suites), and deployed.
 
 **But nobody has played the games yet.**
 
@@ -22,11 +22,11 @@ Both games are deployed to Roblox across 3 environments (dev/staging/prod) — a
 | `apps/dashboard`  | Live on Vercel (internal)                             |
 | `apps/website`    | Live at broblox-games.com                             |
 | CI/CD pipeline    | Green — build, test, lint, publish, promote, rollback |
-| Test coverage     | 3,370+ tests across 145+ test files                   |
+| Test coverage     | 3,773 tests across 172 test suites                    |
 
 ### What's built (do not re-build)
 
-- **35 `@broblox/*` packages** — core, net, combat, matchmaking, moderation, movement, data, config, analytics, notifications, leaderboards, codes, events, inventory, progression, quests, rewards, pets, gacha, cosmetics, battle-pass, marketplace, localization, audio, tutorial, world-systems, ui, input, security, observability, shared-types, constants, equipment, hazards, testing
+- **37 `@broblox/*` packages** — core, net, combat, matchmaking, moderation, movement, data, config, analytics, notifications, leaderboards, codes, events, inventory, progression, quests, rewards, pets, gacha, cosmetics, battle-pass, marketplace, localization, audio, tutorial, world-systems, ui, input, security, observability, shared-types, constants, equipment, hazards, obstacles, game-shared, testing
 - **2 games** (test-park + obby) — fully integrated with all packages
 - **Dashboard v2** — RBAC, audit, bans, flags, match history, news CMS, moderation
 - **Website v1** — homepage, games listing, per-game detail + wiki, rankings, news

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
       - Equipment: modules/equipment.md
       - Events: modules/events.md
       - Gacha: modules/gacha.md
+      - Game Shared: modules/game-shared.md
       - Hazards: modules/hazards.md
       - Input: modules/input.md
       - Inventory: modules/inventory.md


### PR DESCRIPTION
## Docs Sync

Brings documentation in line with the current codebase state after PR #190 and #192.

### Changes

- **Package count**: 33 → 37 in README.md, overview.md, CHANGELOG.md
- **Test count**: "3,100+ tests across 150+ files" → "3,773 tests across 172 test suites" in overview.md
- **New module doc**: Created `docs/modules/game-shared.md` documenting all 7 shared payload types
- **mkdocs.yml**: Added `Game Shared` nav entry
- **Architecture**: Added `game-shared` package description to `folders-and-packages.md`
- **Overview phase table**: Added Phase 5d (equipment, hazards, obstacles) and game-shared rows
- **Input module**: Documented `createInputController()` factory with full API listing
- **README tree**: Added game-shared, equipment, hazards, obstacles to the package listing